### PR TITLE
解决下拉框内tag点击删除树的联动删除效果

### DIFF
--- a/src/views/byui/tree/index.vue
+++ b/src/views/byui/tree/index.vue
@@ -491,7 +491,19 @@ export default {
       allNode.forEach((element) => element.classList.remove("is-current"));
     },
     // select多选时移除某项操作
-    removeSelectTreeTag(val) {},
+    removeSelectTreeTag(val) {
+      // 我假设n叉树中没有重名的叶子节点
+      const stack = JSON.parse(JSON.stringify(this.selectTreeData));
+      while (stack.length) {
+        const curr = stack.shift();
+        if (curr.name == val) {
+          return this.$refs.multipleSelectTree.setChecked(node.id, false);
+        }
+        if (curr.children && curr.children.length) {
+          stack.unshift(...curr.children);
+        }
+      }
+    },
     changeMultipleSelectTreeHandle(val) {},
     // 点击叶子节点
     selectTreeNodeClick(data, node, el) {

--- a/src/views/byui/tree/index.vue
+++ b/src/views/byui/tree/index.vue
@@ -497,7 +497,7 @@ export default {
       while (stack.length) {
         const curr = stack.shift();
         if (curr.name == val) {
-          return this.$refs.multipleSelectTree.setChecked(node.id, false);
+          return this.$refs.multipleSelectTree.setChecked(curr.id, false);
         }
         if (curr.children && curr.children.length) {
           stack.unshift(...curr.children);


### PR DESCRIPTION
由于element提供的remove-tag的返回值是name, 所以在没有重名的情况下是没问题的