### PR TITLE
各处统一 SideBarItem 命名，从而修复菜单加载报错问题

### DIFF
--- a/src/layouts/components/SideBar/SideBarItem.vue
+++ b/src/layouts/components/SideBar/SideBarItem.vue
@@ -46,7 +46,7 @@
         />
         <span>{{ item.meta.title }}</span>
       </template>
-      <sidebar-item
+      <side-bar-item
         v-for="child in item.children"
         :key="child.path"
         :base-path="resolvePath(child.path)"

--- a/src/layouts/components/SideBar/index.vue
+++ b/src/layouts/components/SideBar/index.vue
@@ -14,7 +14,7 @@
       unique-opened
       mode="vertical"
     >
-      <sidebar-item
+      <side-bar-item
         v-for="route in routes"
         :key="route.path"
         :base-path="route.path"
@@ -26,14 +26,14 @@
 <script>
 import path from "path";
 import Logo from "@/layouts/components/Logo";
-import SidebarItem from "./SideBarItem";
+import SideBarItem from "./SideBarItem";
 import variables from "@/styles/variables.scss";
 import { version } from "@/config/settings";
 import { mapGetters } from "vuex";
 
 export default {
   name: "SideBar",
-  components: { SidebarItem, Logo },
+  components: { SideBarItem, Logo },
   data() {
     return { version: version };
   },


### PR DESCRIPTION
今天拉代码后，发现系统菜单加载不出来，原因是各处用到SideBarItem组件命名不统一导致报错：sidebar-item 组件未注册。