### PR TITLE
fix tag bugs

### DIFF
--- a/src/layout/vab-tabs/index.vue
+++ b/src/layout/vab-tabs/index.vue
@@ -98,6 +98,7 @@
             path: tag.path,
             fullPath: tag.fullPath,
             query: tag.query,
+            params: tag.params,
             name: tag.name,
             matched: matched,
             meta: { ...tag.meta },


### PR DESCRIPTION
当路由带有路径参数时，tab点击报错
需在addVisitedRoute方法，加上params方可解决